### PR TITLE
Revert "Use minimal Rust toolchain for packages (#7)"

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1735408444,
-        "narHash": "sha256-Bcf7iBwrfjYPO7roKCz+3yPAFqgNqfKCp51sLKETjxU=",
+        "lastModified": 1743325810,
+        "narHash": "sha256-DgQcRxvWwyH64x8/f6XrAb2CrTtI2WXuA5NRwPLKEVM=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "3c6d3186ab06737d1defd2b5ae556d0ecd161603",
+        "rev": "bfc4e6e8a528dfae8a9d4f2e728eed19f644f8e9",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1734808813,
-        "narHash": "sha256-3aH/0Y6ajIlfy7j52FGZ+s4icVX0oHhqBzRdlOeztqg=",
+        "lastModified": 1742394900,
+        "narHash": "sha256-vVOAp9ahvnU+fQoKd4SEXB2JG2wbENkpqcwlkIXgUC0=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "72e2d02dbac80c8c86bf6bf3e785536acf8ee926",
+        "rev": "70947c1908108c0c551ddfd73d4f750ff2ea67cd",
         "type": "github"
       },
       "original": {
@@ -51,11 +51,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1735471104,
-        "narHash": "sha256-0q9NGQySwDQc7RhAV2ukfnu7Gxa5/ybJ2ANT8DQrQrs=",
+        "lastModified": 1743315132,
+        "narHash": "sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om+D4UnDhlDW9BE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "88195a94f390381c6afcdaa933c2f6ff93959cb4",
+        "rev": "52faf482a3889b7619003c0daec593a1912fddc1",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735784864,
-        "narHash": "sha256-tIl5p3ueaPw7T5T1UXkLc8ISMk6Y8CI/D/rd0msf73I=",
+        "lastModified": 1743388531,
+        "narHash": "sha256-OBcNE+2/TD1AMgq8HKMotSQF8ZPJEFGZdRoBJ7t/HIc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "04d5f1836721461b256ec452883362c5edc5288e",
+        "rev": "011de3c895927300651d9c2cb8e062adf17aa665",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -25,16 +25,6 @@
           rust-overlay.overlays.default
           (final: prev: {
             craneLib = (crane.mkLib prev).overrideToolchain (final.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml);
-            # https://github.com/oxalica/rust-overlay/issues/199
-            craneLibMinimal =
-              let
-                rustToolchainToml = lib.importTOML ./rust-toolchain.toml;
-                rustToolchainTomlMinimal = rustToolchainToml // {
-                  toolchain = lib.removeAttrs rustToolchainToml.toolchain [ "components" ];
-                };
-                rustToolchainTomlFile = final.writers.writeTOML "rust-toolchain-minimal.toml" rustToolchainTomlMinimal;
-              in
-              (crane.mkLib prev).overrideToolchain (final.rust-bin.fromRustupToolchainFile rustToolchainTomlFile);
           })
         ];
       };
@@ -45,7 +35,6 @@
           pkgs = pkgsFor system;
 
           craneLib = pkgs.craneLib;
-          craneLibMinimal = pkgs.craneLibMinimal;
 
           src = lib.fileset.toSource {
             root = ./.;
@@ -69,7 +58,7 @@
           cargoArtifacts = craneLib.buildDepsOnly commonArgs;
         in
         {
-          packages.systemd-credsubst = craneLibMinimal.buildPackage (commonArgs // {
+          packages.systemd-credsubst = craneLib.buildPackage (commonArgs // {
             inherit cargoArtifacts;
             doCheck = false;
             meta.mainProgram = "systemd-credsubst";


### PR DESCRIPTION
Crane now has a `removeReferencesToRustToolchainHook` and enables it by default.