### PR TITLE
Add `install` package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -70,6 +70,19 @@
 
           packages.default = self.packages.${system}.systemd-credsubst;
 
+          packages.install = pkgs.${if pkgs.stdenv.isLinux then "pkgsStatic" else "pkgs"}.callPackage
+            (
+              { uutils-coreutils, rustPlatform }:
+              rustPlatform.buildRustPackage (finalAttrs: {
+                inherit (uutils-coreutils) version src doCheck;
+                pname = "install";
+                cargoLock.lockFile = "${finalAttrs.src}/Cargo.lock";
+                cargoBuildFlags = "-p uu_${finalAttrs.pname}";
+                meta.mainProgram = finalAttrs.pname;
+              })
+            )
+            { };
+
           checks = {
             packages = pkgs.linkFarmFromDrvs "build-all-packages" (lib.attrValues self.packages.${system});
 

--- a/flake.nix
+++ b/flake.nix
@@ -127,11 +127,6 @@
             });
           };
 
-          apps.systemd-credsubst = flake-utils.lib.mkApp {
-            drv = self.packages.${system}.systemd-credsubst;
-          };
-          apps.default = self.apps.${system}.systemd-credsubst;
-
           devShells.default = craneLib.devShell {
             # Inherit inputs from checks.
             checks = self.checks.${system};


### PR DESCRIPTION
It's frequently required to place additional files in `ExecStartPre` with `install`. To not add the entire `coreutils` package to the closure (and `RootDirectory=`), this PR adds a package which contains only the `install` binary. On Linux, the binary is statically linked to prevent pulling in additional runtime dependencies.